### PR TITLE
Make Maps url protocol agnostic

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <script src="bower_components/angular/angular.js"></script>
         <!-- NgMap for heatmap -->
         <script src="bower_components/ngmap/build/scripts/ng-map.min.js"></script>
-        <script src="http://maps.google.com/maps/api/js"></script>
+        <script src="//maps.google.com/maps/api/js"></script>
         <!-- Bower components for Angular/d3 combo -->
         <script src="bower_components/d3/d3.js"></script>
         <script src="bower_components/nvd3/build/nv.d3.js"></script>


### PR DESCRIPTION
This site doesn't load properly because the maps url is being loaded over HTTP